### PR TITLE
Added config option for SLACK_SEND_REPORT

### DIFF
--- a/server/lib/processLogs.js
+++ b/server/lib/processLogs.js
@@ -104,7 +104,11 @@ module.exports = (storage) =>
       const end = current.getTime();
       const start = end - 86400000;
       auth0logger.getReport(start, end)
-        .then(report => slack.send(report, report.checkpoint))
+        .then(report => {
+          if (config('SLACK_SEND_REPORT') === true || config('SLACK_SEND_REPORT') === 'true') {
+            slack.send(report, report.checkpoint)
+          }
+        })
         .then(() => storage.read())
         .then((data) => {
           data.lastReportDate = lastReportDate;

--- a/webtask.json
+++ b/webtask.json
@@ -68,6 +68,22 @@
         }
       ]
     },
+    "SLACK_SEND_REPORT": {
+      "description": "This setting will enable a daily summary report to slack",
+      "type": "select",
+      "allowMultiple": false,
+      "default": "true",
+      "options": [
+        {
+          "value": "false",
+          "text": "No"
+        },
+        {
+          "value": "true",
+          "text": "Yes"
+        }
+      ]
+    },
     "LOG_LEVEL": {
       "description": "This allows you to specify the log level of events that need to be sent",
       "type": "select",


### PR DESCRIPTION
## ✏️ Changes
  
Added a configuration setting for enabling/disabling whether or not to send a daily summary report.
  
## 📷 Screenshots
 
<img width="622" alt="Screenshot 2019-06-26 at 10 34 37" src="https://user-images.githubusercontent.com/16387498/60328933-362c0500-9987-11e9-9592-ee243064f164.png">
  
## 🔗 References
  
Requirement: Needed to have alerts on failure to send logs to a specific channel but don't wan't the channel cluttered when nothing has gone wrong.
  
## 🎯 Testing
  
To test: When SLACK_SEND_REPORT is set to "yes" you will receive a daily summary report. When it is set to "no" you will not.
   
✅ This change has been tested in a Webtask
(although difficult as auth0 get's confused as it's forked from official)
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
N/A 🚫 This change has been tested for performance
  
## 🚀 Deployment
  
Can be deployed anytime. Default behaviour is still the same.
  
✅ This can be deployed any time
  

## 🎡 Rollout
  
In order to verify that the deployment was successful we will manually check the configuration option is present. And manually check that the report is either sent/not sent based on the configurations value.
  
## 🔥 Rollback
  
> Explain when and why we will rollback the change.
  
We will rollback if the manual tests fail or if the configuration option is not present at all.
  
### 📄 Procedure
  
Do not know.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
